### PR TITLE
Fix voor name attribute op circle style voor map waarvoor clustering …

### DIFF
--- a/docs/pages/changelog/index.js
+++ b/docs/pages/changelog/index.js
@@ -17,6 +17,13 @@ const changes = [
         <p><code>vl-annotation</code></p>
         <p>New uig webcomponent to show the web universum vl-annotation.</p>
       </li>
+      <li>
+        <p><code>vl-map-layer-circle-style</code></p>
+        <p>
+          Fixed an issue that data-vl-text-feature-attribute-name attribute was not displaying the feature attribute
+          value for layer-circle-style when the map has clustering disabled.
+        </p>
+      </li>
     </ul>`,
   },
   {

--- a/src/components/map/components/layer-style/layer-circle-style/index.js
+++ b/src/components/map/components/layer-style/layer-circle-style/index.js
@@ -118,7 +118,7 @@ export class VlMapLayerCircleStyle extends VlMapLayerStyle {
     return (feature) => {
       const features = feature && feature.get ? feature.get('features') || [] : [];
 
-      if (Array.isArray(features)) {
+      if (Array.isArray(features) && features.length > 0) {
         const size = features.length || 1;
 
         if (size > 1) {

--- a/src/components/map/components/layer-style/layer-circle-style/layer-circle-style.stories.js
+++ b/src/components/map/components/layer-style/layer-circle-style/layer-circle-style.stories.js
@@ -98,7 +98,7 @@ export const Default = () => {
   </vl-map>`;
 };
 
-export const ManyFeatures = () => {
+export const ManyClusteredFeaturesWithLabels = () => {
   const features = {
     type: 'FeatureCollection',
     features: [
@@ -159,6 +159,80 @@ export const ManyFeatures = () => {
     <vl-map-baselayer-grb-gray></vl-map-baselayer-grb-gray>
 
     <vl-map-features-layer data-vl-cluster data-vl-cluster-distance="100" .features=${features}>
+      <vl-map-layer-circle-style
+        data-vl-color="#ffe615"
+        data-vl-size="10"
+        data-vl-border-color="#000"
+        data-vl-border-size="1"
+        data-vl-text-feature-attribute-name="label"
+        data-vl-text-color="black"
+        data-vl-text-size="20px"
+      ></vl-map-layer-circle-style>
+    </vl-map-features-layer>
+  </vl-map>`;
+};
+
+export const ManyNonClusteredFeaturesWithLabels = () => {
+  const features = {
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: [147055.0, 197108.0],
+        },
+        properties: {
+          label: 'Punt 1',
+        },
+      },
+      {
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: [147155.0, 197208.0],
+        },
+        properties: {
+          label: 'Punt 2',
+        },
+      },
+      {
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: [147255.0, 197308.0],
+        },
+        properties: {
+          label: 'Punt 3',
+        },
+      },
+      {
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: [147355.0, 197308.0],
+        },
+        properties: {
+          label: 'Punt 4',
+        },
+      },
+      {
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: [147455.0, 197408.0],
+        },
+        properties: {
+          label: 'Punt 5',
+        },
+      },
+    ],
+  };
+
+  return html`<vl-map>
+    <vl-map-baselayer-grb-gray></vl-map-baselayer-grb-gray>
+
+    <vl-map-features-layer .features=${features}>
       <vl-map-layer-circle-style
         data-vl-color="#ffe615"
         data-vl-size="10"

--- a/src/components/map/components/layer-style/layer-circle-style/test/unit/layer-circle-style.test.html
+++ b/src/components/map/components/layer-style/layer-circle-style/test/unit/layer-circle-style.test.html
@@ -444,6 +444,36 @@
           const textStyle = style.getText();
           assert.equal(textStyle.getText(), '2');
         });
+
+        test('als er geen featureAttributeName gedefinieerd is én clustering is niet ingeschakeld moet de er geen label van de feature weergegeven', () => {
+          const map = fixture('vl-map-layer-circle-style-fixture');
+          const styleElement = map.querySelector('vl-map-layer-circle-style');
+          assert.equal(styleElement.textFeatureAttributeName, null);
+
+          const feature = new OlFeature({
+            geometry: new OlPoint([109100, 204175]),
+          });
+          feature.set('label', 'feature');
+
+          const style = styleElement.style(feature);
+          const textStyle = style.getText();
+          assert.equal(textStyle.getText(), '');
+        });
+
+        test('als er een featureAttributeName gedefinieerd is én clustering is niet ingeschakeld moet de label van de feature goed weergegeven worden', () => {
+          const map = fixture('vl-map-layer-circle-style-met-text-feature-attribute-name-fixture');
+          const styleElement = map.querySelector('vl-map-layer-circle-style');
+          assert.equal(styleElement.textFeatureAttributeName, 'label');
+
+          const feature = new OlFeature({
+            geometry: new OlPoint([109100, 204175]),
+          });
+          feature.set('label', 'feature');
+
+          const style = styleElement.style(feature);
+          const textStyle = style.getText();
+          assert.equal(textStyle.getText(), 'feature');
+        });
       });
     </script>
   </body>


### PR DESCRIPTION
Fix voor name attribute op circle style voor map waarvoor clustering uitstaat. Story toegevoegd die dit demonstreert in storybook én 2 extra unit tests die dit scenario aftesten.