### PR TITLE
OMGVN-8429: vertalen van zoom in, zoom out en current location tooltips

### DIFF
--- a/src/components/map/actions/custom-map.js
+++ b/src/components/map/actions/custom-map.js
@@ -13,7 +13,6 @@ export class VlCustomMap extends VlMapWithActions {
     options.layers = [options.customLayers.baseLayerGroup, options.customLayers.overlayGroup];
 
     options.controls = [
-      new Zoom(),
       new Rotate(),
       new ScaleLine({
         minWidth: 128,
@@ -33,6 +32,10 @@ export class VlCustomMap extends VlMapWithActions {
     });
 
     super(options);
+
+    if (options.defaultZoom === undefined || options.defaultZoom === true) {
+      this.addControl(new Zoom());
+    }
 
     this.projection = options.projection;
     this.view = options.view;

--- a/src/components/map/components/current-location/current-location.stories.js
+++ b/src/components/map/components/current-location/current-location.stories.js
@@ -1,7 +1,7 @@
 import { html } from 'lit-html';
 import '../../index.js';
 import { CATEGORIES, docsIntro, TYPES } from '../../../../../.storybook/utils.js';
-import { DEFAULT_ZOOM } from '../current-location';
+import { DEFAULT_ZOOM, DEFAULT_TOOLTIP } from '../current-location';
 
 export default {
   title: 'custom-elements/vl-map/vl-map-current-location',
@@ -19,6 +19,7 @@ export default {
   },
   args: {
     zoom: 10,
+    tooltip: 'Huidige locatie',
   },
   argTypes: {
     zoom: {
@@ -32,14 +33,27 @@ export default {
         category: CATEGORIES.ATTRIBUTES,
       },
     },
+    tooltip: {
+      name: 'tooltip',
+      type: { summary: TYPES.STRING, required: false },
+      description: 'Bepaalt de text van de tooltip van de huidige locatie knop.',
+      table: {
+        defaultValue: { summary: DEFAULT_TOOLTIP },
+        category: CATEGORIES.ATTRIBUTES,
+      },
+    },
   },
 };
 
 //--------------------------
 
-const Template = ({ zoom }) => html`<vl-map id="map">
+const Template = ({ zoom, tooltip }) => html`<vl-map
+  id="map"
+  data-vl-zoomInTooltip="Zoom in"
+  data-vl-zoomOutTooltip="Zoom uit"
+>
   <vl-map-baselayer-grb-gray></vl-map-baselayer-grb-gray>
-  <vl-map-current-location data-vl-zoom="${zoom}"></vl-map-current-location>
+  <vl-map-current-location data-vl-zoom="${zoom}" data-vl-tooltip="${tooltip}"></vl-map-current-location>
 </vl-map> `;
 
 export const Default = Template.bind({});

--- a/src/components/map/components/current-location/index.js
+++ b/src/components/map/components/current-location/index.js
@@ -5,6 +5,7 @@ import '../../../icon';
 import iconStyles from '../../../icon/styles.scss';
 
 export const DEFAULT_ZOOM = 10;
+export const DEFAULT_TOOLTIP = 'Current location ddd';
 
 export class VlMapCurrentLocation extends LitElement {
   static get styles() {
@@ -25,6 +26,11 @@ export class VlMapCurrentLocation extends LitElement {
         attribute: 'data-vl-zoom',
         reflect: true,
       },
+      tooltip: {
+        type: String,
+        attribute: 'data-vl-tooltip',
+        reflect: true,
+      },
     };
   }
 
@@ -32,6 +38,7 @@ export class VlMapCurrentLocation extends LitElement {
     super();
 
     this.zoom = DEFAULT_ZOOM;
+    this.tooltip = DEFAULT_TOOLTIP;
   }
 
   connectedCallback() {
@@ -54,7 +61,7 @@ export class VlMapCurrentLocation extends LitElement {
 
   render() {
     return html`<div class="uig-map-current-location">
-      <button @click=${() => this._currentLocation()} type="button" title="Current location">
+      <button @click=${() => this._currentLocation()} type="button" title="${this.tooltip}">
         <span is="vl-icon" data-vl-icon="location-gps"></span>
       </button>
     </div>`;

--- a/src/components/map/components/map/index.js
+++ b/src/components/map/components/map/index.js
@@ -7,6 +7,7 @@ import { VlCustomMap } from '../../actions/custom-map';
 import { EVENT } from '../../enums';
 
 import styles from './styles.scss';
+import { Zoom } from 'ol/control.js';
 
 export class VlMap extends vlElement(HTMLElement) {
   constructor() {
@@ -131,11 +132,29 @@ export class VlMap extends vlElement(HTMLElement) {
       projection: this._projection,
       target: this._mapElement,
       controls: this._controls,
+      defaultZoom: false,
     });
 
     this._map.initializeView();
     this.__updateMapSizeOnLoad();
     this.__updateOverviewMapSizeOnLoad();
+
+    this._map.addControl(this.__createZoomControl());
+  }
+
+  __createZoomControl() {
+    const zoomOptions = {};
+    if (this.zoomInTipLabel) zoomOptions.zoomInTipLabel = this.zoomInTipLabel;
+    if (this.zoomOutTipLabel) zoomOptions.zoomOutTipLabel = this.zoomOutTipLabel;
+    return new Zoom(zoomOptions);
+  }
+
+  get zoomInTipLabel() {
+    return this.getAttribute('data-vl-zoomInTooltip');
+  }
+
+  get zoomOutTipLabel() {
+    return this.getAttribute('data-vl-zoomOutTooltip');
   }
 
   addLayer(layer) {
@@ -271,7 +290,7 @@ export class VlMap extends vlElement(HTMLElement) {
    * Render the map again.
    */
   rerender() {
-    this.map.render();
+    this.map.this.map.render();
   }
 
   __updateMapSize() {

--- a/src/components/map/components/map/map.stories.js
+++ b/src/components/map/components/map/map.stories.js
@@ -97,6 +97,8 @@ const Template = ({ allowFullscreen, disableEscape, disableRotation, disableMous
     ?data-vl-disable-escape-key=${disableEscape}
     ?data-vl-disable-rotation=${disableRotation}
     ?data-vl-disable-mouse-wheel-zoom=${disableMousewheelZoom}
+    data-vl-zoomInTooltip="Zoom in"
+    data-vl-zoomOutTooltip="Zoom uit"
   >
     <vl-map-baselayer-grb-gray></vl-map-baselayer-grb-gray>
   </vl-map>


### PR DESCRIPTION
Tooltips van de zoom en current location controls moeten configureerbaar zijn zodat ze de tekst kunnen tonen in de taal waarin het inzage loket getoond wordt.