### PR TITLE
Feature/extra auto complete features

### DIFF
--- a/docs/pages/changelog/index.js
+++ b/docs/pages/changelog/index.js
@@ -24,6 +24,13 @@ const changes = [
         <p><code>vl-map</code></p>
         <p>Fix: voorzien van attributen om tooltip tekst van zoom in, zoom out en current location te bepalen.</p>
       </li>
+      <li>
+        <p><code>vl-functional-header</code></p>
+        <p>
+          Fix: toevoegen van e2e testen, add label attribute, implementeren van initial value, implementeren van clear
+          knop.
+        </p>
+      </li>
     </ul>`,
   },
   {

--- a/src/components/autocomplete/autocomplete.stories.js
+++ b/src/components/autocomplete/autocomplete.stories.js
@@ -30,10 +30,13 @@ export default {
   },
   args: {
     placeholder: 'Hint: typ Gent',
+    initialValue: '',
+    label: '',
     minChars: 1,
     maxSuggestions: 5,
     captionFormat: CAPTION_FORMAT.TITLE_SUBTITLE_VERTICAL,
     groupBy: '',
+    showClear: false,
     items: complexItems,
   },
   argTypes: {
@@ -41,6 +44,24 @@ export default {
       name: 'placeholder',
       type: { summary: TYPES.STRING, required: false },
       description: 'Attribuut wordt gebruikt om de placeholder te bepalen.',
+      table: {
+        defaultValue: { summary: '' },
+        category: CATEGORIES.ATTRIBUTES,
+      },
+    },
+    initialValue: {
+      name: 'data-vl-initial-value',
+      type: { summary: TYPES.STRING, required: false },
+      description: 'Attribuut wordt gebruikt om de initiële waarde te bepalen.',
+      table: {
+        defaultValue: { summary: '' },
+        category: CATEGORIES.ATTRIBUTES,
+      },
+    },
+    label: {
+      name: 'data-vl-label',
+      type: { summary: TYPES.STRING, required: false },
+      description: 'Attribuut wordt gebruikt om de label te bepalen.',
       table: {
         defaultValue: { summary: '' },
         category: CATEGORIES.ATTRIBUTES,
@@ -108,6 +129,15 @@ export default {
         category: CATEGORIES.ATTRIBUTES,
       },
     },
+    showClear: {
+      name: 'showClear',
+      type: { summary: TYPES.BOOLEAN, required: false },
+      description: 'Attribuut wordt gebruikt te bepalen of het clear icoon moet tevoorschijn komen.',
+      table: {
+        defaultValue: { summary: '' },
+        category: CATEGORIES.ATTRIBUTES,
+      },
+    },
     items: {
       description: 'Use this property when you want to use a static list of items.',
       type: { summary: 'array' },
@@ -128,13 +158,26 @@ export default {
 
 //--------------------------
 
-const Template = ({ placeholder, minChars, maxSuggestions, captionFormat, groupBy, items }) => html`
+const Template = ({
+  placeholder,
+  initialValue,
+  label,
+  minChars,
+  maxSuggestions,
+  captionFormat,
+  groupBy,
+  items,
+  showClear,
+}) => html`
   <vl-autocomplete
     placeholder=${placeholder}
+    data-vl-initial-value=${initialValue}
+    data-vl-label=${label}
     data-vl-min-chars=${minChars}
     data-vl-max-suggestions=${maxSuggestions}
     data-vl-caption-format=${captionFormat}
     data-vl-group-by=${groupBy}
+    ?data-vl-show-clear=${showClear}
     .items=${items}
   ></vl-autocomplete>
 `;
@@ -165,6 +208,7 @@ export const WithCustomCaptionFormatter = () => html` <vl-autocomplete
   .items=${complexItems}
   data-vl-caption-format="${CAPTION_FORMAT.SUBTITLE_TITLE_HORIZONTAL}"
   placeholder="Hint: typ Gent"
+  @clear=${() => console.log('autocomplete cleared!!!')}
 ></vl-autocomplete>`;
 
 //--------------------------
@@ -197,14 +241,12 @@ async function fetchDataFromMockedApiCall(autocomplete, searchTerm) {
   }));
 }
 
-export const WithInputAndMockedApiCall = () => html`
-  <vl-autocomplete
-    @search=${(e) => fetchDataFromMockedApiCall(e.target, e.detail.searchTerm)}
-    placeholder="Gemeente, Straat of Project"
-    data-vl-min-chars="2"
-    data-vl-max-suggestions="5"
-  ></vl-autocomplete>
-`;
+export const WithInputAndMockedApiCall = () => html`<vl-autocomplete
+  @search=${(e) => fetchDataFromMockedApiCall(e.target, e.detail.searchTerm)}
+  placeholder="Gemeente, Straat of Project"
+  data-vl-min-chars="2"
+  data-vl-max-suggestions="5"
+></vl-autocomplete>`;
 
 //-------------------------
 

--- a/src/components/autocomplete/styles.scss
+++ b/src/components/autocomplete/styles.scss
@@ -1,14 +1,37 @@
 @charset "utf-8";
-@import "../../../node_modules/@govflanders/vl-ui-core/src/scss/core";
-@import "../../../node_modules/@govflanders/vl-ui-core-4.1.24/src/scss/generic/iconfont";
-@import "../../../node_modules/@govflanders/vl-ui-autocomplete/src/scss/autocomplete";
-@import "../../../node_modules/@govflanders/vl-ui-input-field/src/scss/input-field";
-@import "../../../node_modules/@govflanders/vl-ui-util/src/scss/util";
+@import '../../../node_modules/@govflanders/vl-ui-core/src/scss/core';
+@import '../../../node_modules/@govflanders/vl-ui-core-4.1.24/src/scss/generic/iconfont';
+@import '../../../node_modules/@govflanders/vl-ui-autocomplete/src/scss/autocomplete';
+@import '../../../node_modules/@govflanders/vl-ui-input-field/src/scss/input-field';
+@import '../../../node_modules/@govflanders/vl-ui-util/src/scss/util';
 
 li.uig-autocomplete-group {
   font-weight: bold;
 }
 
-.js-vl-autocomplete div.vl-autocomplete__list-wrapper, .js-vl-autocomplete div.autocomplete__list-wrapper  {
+.js-vl-autocomplete div.vl-autocomplete__list-wrapper,
+.js-vl-autocomplete div.autocomplete__list-wrapper {
   max-height: 100vh;
+}
+
+.js-vl-autocomplete .ui-autocomplete__loader-with-clear {
+  right: 20px;
+}
+
+.uig-autocomplete__clear {
+  position: absolute;
+  top: 0px;
+  right: 0px;
+  width: 25px;
+  height: 3.5rem;
+  z-index: 2;
+}
+
+.uig-autocomplete__clear .uig-autocomplete__clear-icon::before {
+  display: block;
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  margin-top: 4px;
+  cursor: pointer;
 }

--- a/src/components/autocomplete/test/e2e/autocomplete.js
+++ b/src/components/autocomplete/test/e2e/autocomplete.js
@@ -6,6 +6,39 @@ export class VlTestAutocomplete extends VlElement {
     return input.getAttribute('placeholder');
   }
 
+  async _getInput() {
+    const inputElement = await this.shadowRoot.findElement(By.css('input'));
+    return new VlElement(this.driver, inputElement);
+  }
+
+  async getValue() {
+    const inputVlElement = await this._getInput();
+    return inputVlElement.getAttribute('value');
+  }
+
+  async getLabel() {
+    const input = await this.getElementInShadow(this, 'label');
+    return input.getText();
+  }
+
+  async assertHasClearIcon() {
+    await this.waitUntilShadowDomElementsCount(this, '.uig-autocomplete__clear', 1);
+  }
+
+  async assertHasNoClearIcon() {
+    await this.waitUntilShadowDomElementsCount(this, '.uig-autocomplete__clear', 0);
+  }
+
+  async clickOnClearIcon() {
+    const element = await this._getClearIcon();
+    await element.click();
+  }
+
+  async _getClearIcon() {
+    const element = await this.shadowRoot.findElement(By.css('.uig-autocomplete__clear'));
+    return new VlElement(this.driver, element);
+  }
+
   async isDisabled() {
     return this.hasAttribute('disabled');
   }

--- a/src/components/autocomplete/test/e2e/autocomplete.spec.js
+++ b/src/components/autocomplete/test/e2e/autocomplete.spec.js
@@ -8,6 +8,11 @@ const minCharsUrl = `${defaultUrl}&args=minChars:3`;
 const maxSuggestionsUrl = `${defaultUrl}&args=maxSuggestions:3`;
 const groupByUrl = `${defaultUrl}&args=groupBy:subtitle`;
 const captionFormatTitleOnlyUrl = `${defaultUrl}&args=captionFormat:title-only`;
+const withShowClearUrl = `${defaultUrl}&args=showClear:true`;
+const initialValueWithShowClearUrl = `${defaultUrl}&args=initialValue:waarde;showClear:true`;
+const initialValueWithoutShowClearUrl = `${defaultUrl}&args=initialValue:waarde`;
+const withLabelUrl = `${defaultUrl}&args=label:Zoekveld`;
+const withInitialValueUrl = `${defaultUrl}&args=initialValue:Eerste waarde`;
 const selector = 'vl-autocomplete';
 
 const mockedApiCallUrl = `${sbUrl}?id=custom-elements-vl-autocomplete--with-input-and-mocked-api-call`;
@@ -172,5 +177,69 @@ describe('vl-autocomplete', async () => {
       { title: 'Drabstraat, Mortsel' },
       { title: 'Drabstraat, Wichelen' },
     ]);
+  });
+
+  it('as a user, I can see the autocomplete initial value and clear icon if showClear attribute is set', async () => {
+    await driver.get(initialValueWithShowClearUrl);
+    const autocomplete = await new VlTestAutocomplete(driver, selector);
+
+    const value = await autocomplete.getValue();
+    assert.equal(value, 'waarde');
+
+    await autocomplete.assertHasClearIcon();
+  });
+
+  it('as a user, I can see the autocomplete initial value and no clear icon if showClear attribute is not set', async () => {
+    await driver.get(initialValueWithoutShowClearUrl);
+    const autocomplete = await new VlTestAutocomplete(driver, selector);
+
+    const value = await autocomplete.getValue();
+    assert.equal(value, 'waarde');
+
+    await autocomplete.assertHasNoClearIcon();
+  });
+
+  it('as a user, I can see clear icon if showClear attribute is set and a value is typed', async () => {
+    await driver.get(withShowClearUrl);
+    const autocomplete = await new VlTestAutocomplete(driver, selector);
+
+    let value = await autocomplete.getValue();
+    assert.equal(value, '');
+    await autocomplete.assertHasNoClearIcon();
+
+    await autocomplete.setInputValue('g');
+
+    const suggestions = await autocomplete.getSuggestions();
+    const size = suggestions.length;
+    assert.equal(size, 5);
+
+    value = await autocomplete.getValue();
+    assert.equal(value, 'g');
+    await autocomplete.assertHasClearIcon();
+
+    await autocomplete.clickOnClearIcon();
+
+    value = await autocomplete.getValue();
+    assert.equal(value, '');
+
+    await autocomplete.assertHasNoClearIcon();
+
+    await autocomplete.assertSuggestionsCount(0);
+  });
+
+  it('as a user, I can see the autocomplete label', async () => {
+    await driver.get(withLabelUrl);
+    const autocomplete = await new VlTestAutocomplete(driver, selector);
+
+    const text = await autocomplete.getLabel();
+    assert.equal('Zoekveld', text);
+  });
+
+  it('as a user, I can see the autocomplete with an initial value', async () => {
+    await driver.get(withInitialValueUrl);
+    const autocomplete = await new VlTestAutocomplete(driver, selector);
+
+    const value = await autocomplete.getValue();
+    assert.equal(value, 'Eerste waarde');
   });
 });


### PR DESCRIPTION
- Zorg ervoor dat de initial value die getoond wordt in de dropdown gezet kan worden

- De component moet een attribuut krijgen vl-data-toon-clear wanneer dit gezet is moet de component een clear icoon krijgen. Als er data in het input veld staat moet dit icoon zichtbaar zijn. Bij het klikken op het icoon moet de inhoud van het input veld leeg gemaakt worden, mogen er geen suggesties getoond worden en moet een custom onClear event gegooid worden zodat de afnemende applicatie op deze event kan luisteren.

- Het moet mogelijk zijn om een label te definiëren voor de autocomplete. Bij het klikken op de label moet bijgevolg ook de focus op de autocomplete gezet worden.