### PR TITLE
OMGVN-8657: New attribute data-vl-no-matches-text to configure the te…

### DIFF
--- a/docs/pages/changelog/index.js
+++ b/docs/pages/changelog/index.js
@@ -25,16 +25,24 @@ const changes = [
         <p>Fix: voorzien van attributen om tooltip tekst van zoom in, zoom out en current location te bepalen.</p>
       </li>
       <li>
-        <p><code>vl-functional-header</code></p>
+        <p><code>vl-auto-complete</code></p>
         <p>
-          Fix: toevoegen van e2e testen, add label attribute, implementeren van initial value, implementeren van clear
-          knop.
+          Fix: toevoegen van e2e testen, add label attribute (data-vl-label), implementeren van initial value
+          (data-vl-initial-value), implementeren van clear (data-vl-show-clear) knop.
         </p>
       </li>
       <li>
         <p><code>vl-data-table</code></p>
         <p>
-          Fix: Aanpassing in storybook. Om de header te tonen op kleinere schermen moet de header gezet worden als data-title attribuut.
+          Fix: Aanpassing in storybook. Om de header te tonen op kleinere schermen moet de header gezet worden als
+          data-title attribuut.
+        </p>
+      </li>
+      <li>
+        <p><code>vl-auto-complete</code></p>
+        <p>
+          Fix: new attribute data-vl-no-matches-text to configure the text to be displayed when there are no
+          suggestions.
         </p>
       </li>
     </ul>`,

--- a/src/components/autocomplete/autocomplete.stories.js
+++ b/src/components/autocomplete/autocomplete.stories.js
@@ -37,6 +37,7 @@ export default {
     captionFormat: CAPTION_FORMAT.TITLE_SUBTITLE_VERTICAL,
     groupBy: '',
     showClear: false,
+    noMatchesText: 'Geen resultaat',
     items: complexItems,
   },
   argTypes: {
@@ -138,6 +139,15 @@ export default {
         category: CATEGORIES.ATTRIBUTES,
       },
     },
+    noMatchesText: {
+      name: 'data-vl-no-matches-text',
+      type: { summary: TYPES.STRING, required: false },
+      description: 'Attribuut wordt gebruikt de tekst te bepalen die getoond moet worden als er geen suggesties zijn.',
+      table: {
+        defaultValue: { summary: '' },
+        category: CATEGORIES.ATTRIBUTES,
+      },
+    },
     items: {
       description: 'Use this property when you want to use a static list of items.',
       type: { summary: 'array' },
@@ -168,6 +178,7 @@ const Template = ({
   groupBy,
   items,
   showClear,
+  noMatchesText,
 }) => html`
   <vl-autocomplete
     placeholder=${placeholder}
@@ -178,6 +189,7 @@ const Template = ({
     data-vl-caption-format=${captionFormat}
     data-vl-group-by=${groupBy}
     ?data-vl-show-clear=${showClear}
+    data-vl-no-matches-text=${noMatchesText}
     .items=${items}
   ></vl-autocomplete>
 `;

--- a/src/components/autocomplete/index.js
+++ b/src/components/autocomplete/index.js
@@ -46,6 +46,7 @@ export class VlAutocomplete extends LitElement {
       initialValue: { type: String, attribute: 'data-vl-initial-value', reflect: true },
       showClear: { type: Boolean, attribute: 'data-vl-show-clear', reflect: true },
       label: { type: String, attribute: 'data-vl-label', reflect: true },
+      noMatchesText: { type: String, attribute: 'data-vl-no-matches-text', reflect: true },
     };
   }
 
@@ -89,6 +90,8 @@ export class VlAutocomplete extends LitElement {
 
     this.maxSuggestions = DEFAULT_MAX_MATCHES;
     this.captionFormat = DEFAULT_CAPTION_FORMAT;
+
+    this.noMatchesText = 'Sorry, no matches.';
   }
 
   firstUpdated() {
@@ -281,7 +284,7 @@ export class VlAutocomplete extends LitElement {
 
       this._groupedMatches = new Map();
       if (this._matches.length > 0) {
-        if (this.groupBy != null) {
+        if (this.groupBy != null && this.groupBy.length > 0) {
           this._matches.forEach((item) => {
             const groupByValue = item[this.groupBy];
             let group = this._groupedMatches.get(groupByValue);
@@ -297,7 +300,7 @@ export class VlAutocomplete extends LitElement {
         }
       } else {
         this._matches = [];
-        this._matches.push({ value: null, title: 'Sorry, No matches' });
+        this._matches.push({ value: null, title: this.noMatchesText });
         this.firstValidItemIndex = null;
       }
     } else {


### PR DESCRIPTION
OMGVN-8657: New attribute data-vl-no-matches-text to configure the text to be displayed when there are no suggestions. Kleine correctie in changelog. En kleine fix voor correct highlighten van eerste waarde n suggestielijst.